### PR TITLE
Fix typo in spawn manager initializer

### DIFF
--- a/Assets/Scripts/Spawn System/Core/ObjectSpawner.cs
+++ b/Assets/Scripts/Spawn System/Core/ObjectSpawner.cs
@@ -16,7 +16,7 @@ public abstract class ObjectSpawner : MonoBehaviour
 
     private void Start()
     {
-        InitializeSpawnPoinManager();
+        InitializeSpawnPointManager();
     }
 
     protected virtual void Update()
@@ -43,7 +43,7 @@ public abstract class ObjectSpawner : MonoBehaviour
         return 0;
     }
 
-    private void InitializeSpawnPoinManager()
+    private void InitializeSpawnPointManager()
     {
         spawnPointManager = FindObjectOfType<SpawnPointManager>();
         if (spawnPointManager == null)


### PR DESCRIPTION
## Summary
- rename `InitializeSpawnPoinManager` to `InitializeSpawnPointManager`
- update call site in `Start()`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842dc40c8988323a2bc23367f7c0a6e